### PR TITLE
Add tab for Dataset Visualization types

### DIFF
--- a/docs/ai_worker/dataset_preparation_with_web_ui_ai_worker.md
+++ b/docs/ai_worker/dataset_preparation_with_web_ui_ai_worker.md
@@ -204,12 +204,22 @@ Once data collection is complete, you can preview and inspect your recorded data
 cd /root/ros2_ws/src/physical_ai_tools/lerobot
 ```
 
+:::tabs key:robot-type
+== BG2 Type
 ```bash
 python lerobot/scripts/visualize_dataset_html.py \
   --host 0.0.0.0 \
   --port 9091 \
-  --repo-id ${HF_USER}/ffw_test
+  --repo-id ${HF_USER}/ffw_bg2_rev4_test
 ```
+== SG2 Type
+```bash
+python lerobot/scripts/visualize_dataset_html.py \
+  --host 0.0.0.0 \
+  --port 9091 \
+  --repo-id ${HF_USER}/ffw_sg2_rev1_test
+```
+:::
 
 You should see an output similar to the following:
 


### PR DESCRIPTION
Introduce a new tab in the Dataset Visualization section to differentiate between BG2 and SG2 types, enhancing user experience and clarity.