### PR TITLE
Update running teleoperation guide for AI Worker

### DIFF
--- a/docs/ai_worker/operation_ai_worker.md
+++ b/docs/ai_worker/operation_ai_worker.md
@@ -35,22 +35,44 @@ It can be worn more easily by users with different body types.
 The following teleoperation commands are executed on the `robot PC`.
 You can either connect a keyboard and mouse directly to the Nvidia Orin, or access it via SSH (see the Setup Guide for instructions).<br>
 
-If no containers are running when you execute `docker ps -a` on the robot PC,
-start the container using:
+
+Enter the **ai\_worker** Docker container with:
 
 ```bash
-cd ai_worker
-```
-
-```bash
-./docker/container.sh start
-```
-
-If a container is already running, enter the **ai\_worker** Docker container with:
-
-```bash
+cd ~/ai_worker
 ./docker/container.sh enter
 ```
+
+::: info 
+
+**If you encounter this error:**
+```
+Error: Container is not running
+```
+
+Follow these troubleshooting steps:
+
+**Step 1: Check Container Status**
+```bash
+docker ps -a
+```
+
+**Step 2: Start the Container**
+If the `ai_worker` container is not running, navigate to the ai_worker directory and start the container:
+
+⚠️ **IMPORTANT** ⚠️
+
+Before starting the container, 
+
+**you MUST ensure that the AI Worker is connected to the internet via LAN cable**. 
+
+Starting the container without internet connection may cause ZED calibration data to be lost.
+
+```bash
+cd ~/ai_worker
+./docker/container.sh start
+```
+:::
 
 ### Option 1: All-in-One Launch
 

--- a/docs/ai_worker/operation_ai_worker.md
+++ b/docs/ai_worker/operation_ai_worker.md
@@ -72,6 +72,11 @@ Starting the container without internet connection may cause ZED calibration dat
 cd ~/ai_worker
 ./docker/container.sh start
 ```
+
+:::
+
+::: warning
+If you executed `./docker/container.sh start` in the previous step, **keep the internet connection active during the first execution** of the commands below. The system needs to download and initialize components including ZED calibration data on the first run.
 :::
 
 ### Option 1: All-in-One Launch

--- a/docs/ai_worker/operation_ai_worker.md
+++ b/docs/ai_worker/operation_ai_worker.md
@@ -43,42 +43,6 @@ cd ~/ai_worker
 ./docker/container.sh enter
 ```
 
-::: info 
-
-**If you encounter this error:**
-```
-Error: Container is not running
-```
-
-Follow these troubleshooting steps:
-
-**Step 1: Check Container Status**
-```bash
-docker ps -a
-```
-
-**Step 2: Start the Container**
-If the `ai_worker` container is not running, navigate to the ai_worker directory and start the container:
-
-⚠️ **IMPORTANT** ⚠️
-
-Before starting the container, 
-
-**you MUST ensure that the AI Worker is connected to the internet via LAN cable**. 
-
-Starting the container without internet connection may cause ZED calibration data to be lost.
-
-```bash
-cd ~/ai_worker
-./docker/container.sh start
-```
-
-:::
-
-::: warning
-If you executed `./docker/container.sh start` in the previous step, **keep the internet connection active during the first execution** of the commands below. The system needs to download and initialize components including ZED calibration data on the first run.
-:::
-
 ### Option 1: All-in-One Launch
 
 ::: tip

--- a/docs/ai_worker/operation_ai_worker.md
+++ b/docs/ai_worker/operation_ai_worker.md
@@ -36,7 +36,7 @@ The following teleoperation commands are executed on the `robot PC`.
 You can either connect a keyboard and mouse directly to the Nvidia Orin, or access it via SSH (see the Setup Guide for instructions).<br>
 
 
-Enter the **ai\_worker** Docker container with:
+Enter the **ai_worker** Docker container with:
 
 ```bash
 cd ~/ai_worker


### PR DESCRIPTION
### Changes
 - Remove Docker container start section for non-running ai_worker container from operation guide


#### Before

<img width="550" height="534" alt="image" src="https://github.com/user-attachments/assets/be6a78b4-f00f-44d3-a4aa-aefaae2ea150" />


#### After

<img width="550" height="313" alt="image" src="https://github.com/user-attachments/assets/762bf584-ee6d-4a2c-8acd-430c03c35877" />
