### PR TITLE
Added drawing file download links in OMX and OMY documentation

### DIFF
--- a/docs/omx/hardware_omx.md
+++ b/docs/omx/hardware_omx.md
@@ -25,7 +25,7 @@ The OMX hardware platform is an entry-level Physical AI manipulator designed for
 ## [Follower] Layout
 ![](/specifications/omx/omx_follower_layout.png)
 
-### **Drawing**
+### **Drawing Files**
 
 | File Type | Download Link |
 |-----------|---------------|
@@ -54,7 +54,7 @@ The OMX hardware platform is an entry-level Physical AI manipulator designed for
 ## [Leader] Layout
 ![](/specifications/omx/omx_leader_layout.png)
 
-### **Drawing**
+### **Drawing Files**
 
 | File Type | Download Link |
 |-----------|---------------|

--- a/docs/omx/hardware_omx.md
+++ b/docs/omx/hardware_omx.md
@@ -25,6 +25,8 @@ The OMX hardware platform is an entry-level Physical AI manipulator designed for
 ## [Follower] Layout
 ![](/specifications/omx/omx_follower_layout.png)
 
+- `Download` [PDF](https://www.robotis.com/service/download.php?no=2223), [STEP](https://www.robotis.com/service/download.php?no=2224)
+
 ## [Leader] Hardware Overview
 
 ![](/specifications/omx/hw_overview_omx_l.png)
@@ -46,3 +48,5 @@ The OMX hardware platform is an entry-level Physical AI manipulator designed for
 
 ## [Leader] Layout
 ![](/specifications/omx/omx_leader_layout.png)
+
+- `Download` [PDF](https://www.robotis.com/service/download.php?no=2225), [STEP](https://www.robotis.com/service/download.php?no=2226)

--- a/docs/omx/hardware_omx.md
+++ b/docs/omx/hardware_omx.md
@@ -25,7 +25,12 @@ The OMX hardware platform is an entry-level Physical AI manipulator designed for
 ## [Follower] Layout
 ![](/specifications/omx/omx_follower_layout.png)
 
-- `Download` [PDF](https://www.robotis.com/service/download.php?no=2223), [STEP](https://www.robotis.com/service/download.php?no=2224)
+### **Drawing**
+
+| File Type | Download Link |
+|-----------|---------------|
+| PDF | [📄 Download PDF](https://www.robotis.com/service/download.php?no=2223) |
+| STEP | [📦 Download STEP](https://www.robotis.com/service/download.php?no=2224) |
 
 ## [Leader] Hardware Overview
 
@@ -49,4 +54,9 @@ The OMX hardware platform is an entry-level Physical AI manipulator designed for
 ## [Leader] Layout
 ![](/specifications/omx/omx_leader_layout.png)
 
-- `Download` [PDF](https://www.robotis.com/service/download.php?no=2225), [STEP](https://www.robotis.com/service/download.php?no=2226)
+### **Drawing**
+
+| File Type | Download Link |
+|-----------|---------------|
+| PDF | [📄 Download PDF](https://www.robotis.com/service/download.php?no=2225) |
+| STEP | [📦 Download STEP](https://www.robotis.com/service/download.php?no=2226) |

--- a/docs/omx/lerobot_imitation_learning_omx.md
+++ b/docs/omx/lerobot_imitation_learning_omx.md
@@ -35,7 +35,9 @@ For the purposes of this tutorial, we assume:
 - Follower’s port → /dev/ttyACM0
 - Leader’s port → /dev/ttyACM1
 
-## Data Collection
+## Teleoperation
+
+You can test if OMX is working properly through teleoperation. 
 
 ### 1. Teleoperate OMX
 
@@ -53,7 +55,7 @@ python -m lerobot.teleoperate \
 
 > **Note**: the `--robot.id/--teleop.id` values persist metadata (e.g., calibrations/settings). Use consistent IDs across teleop, recording, and evaluation for the same setup.
 
-### 2. Teleoperate with cameras
+### 2. Teleoperate with camera
 
 For camera integration:
 
@@ -69,7 +71,9 @@ python -m lerobot.teleoperate \
     --display_data=true
 ```
 
-### 3. Record Dataset
+## Data Collection
+
+### 1. Record Dataset
 
 We use the Hugging Face hub features for uploading your dataset. If you haven’t previously used the Hub, make sure you can log in via the CLI using a write-access token, this token can be generated from the Hugging Face settings.
 
@@ -87,6 +91,8 @@ echo $HF_USER
 
 Record your first dataset:
 
+> **Note**: If you have teleoperation running from the previous step, please stop it first before running this command as it includes teleoperation with camera.
+
 ```bash
 lerobot-record \
     --robot.type=omx_follower \
@@ -102,18 +108,7 @@ lerobot-record \
     --dataset.single_task="Pick up the Dynamixel Motor"
 ```
 
-### 4. Dataset Management
-
-**Local Storage:**
-- Dataset stored in: `~/.cache/huggingface/lerobot/{repo-id}`
-
-**Dataset Upload:**
-```bash
-huggingface-cli upload ${HF_USER}/record-test ~/.cache/huggingface/lerobot/${HF_USER}/record-test --repo-type dataset
-echo https://huggingface.co/datasets/${HF_USER}/record-test
-```
-
-### 5. Recording Controls & Details
+### 2. Recording Controls & Details
 
 **Keyboard Shortcuts:**
 - **Right Arrow (→)**: End episode and move to next
@@ -131,6 +126,18 @@ echo https://huggingface.co/datasets/${HF_USER}/record-test
 - Disable automatic push to the Hub with `--dataset.push_to_hub=false`
 - Resume a failed/interrupted session with `--resume=true`
   - When resuming, set `--dataset.num_episodes` to the number of additional episodes to record (not the final total)
+
+
+### 3. Dataset Management
+
+**Local Storage:**
+- Dataset stored in: `~/.cache/huggingface/lerobot/{repo-id}`
+
+**Dataset Upload:**
+```bash
+huggingface-cli upload ${HF_USER}/record-test ~/.cache/huggingface/lerobot/${HF_USER}/record-test --repo-type dataset
+echo https://huggingface.co/datasets/${HF_USER}/record-test
+```
 
 ## Data Visualization
 

--- a/docs/omx/lerobot_imitation_learning_omx.md
+++ b/docs/omx/lerobot_imitation_learning_omx.md
@@ -6,6 +6,8 @@ This tutorial explains how to train a neural network to control OMX autonomously
 
 By following these steps, you'll be able to replicate tasks such as picking up objects and placing them with high success rates.
 
+> **Note**: This tutorial is based on the [Hugging Face LeRobot documentation](https://huggingface.co/docs/lerobot/getting_started_real_world_robot) and adapted specifically for OMX hardware setup.
+
 ## Before You Begin
 
 First, identify the bus servo adapter ports for the leader and follower by running the following command:
@@ -123,7 +125,7 @@ lerobot-record \
 ```
 
 **Additional behavior:**
-- Disable automatic push to the Hub with `--dataset.push_to_hub=false`
+- Disable automatic push to the Hub with `--dataset.push_to_hub=false` (default: `true`)
 - Resume a failed/interrupted session with `--resume=true`
   - When resuming, set `--dataset.num_episodes` to the number of additional episodes to record (not the final total)
 
@@ -143,7 +145,7 @@ echo https://huggingface.co/datasets/${HF_USER}/record-test
 
 ### View Dataset Online
 
-If uploaded with `--control.push_to_hub=true`:
+If uploaded to the Hub (either by default behavior or with `--dataset.push_to_hub=true`), you can [visualize your dataset online](https://huggingface.co/spaces/lerobot/visualize_dataset) by copy pasting your repo id given by:
 
 ```bash
 echo ${HF_USER}/record-test
@@ -230,9 +232,9 @@ python -m lerobot.record \
   --policy.path=${HF_USER}/omx_act_policy
 ```
 
-**Note**: use an `eval_*` dataset name (e.g., `eval_act_omx`) to clearly separate evaluation runs.
+> **Note**: use an `eval_*` dataset name (e.g., `eval_act_omx`) to clearly separate evaluation runs.
 
 As you can see, it’s almost the same command as previously used to record your training dataset. Two things have changed:
 
-- There is an additional `--control.policy.path` argument which indicates the path to your policy checkpoint (e.g., `outputs/train/eval_act_omx/checkpoints/last/pretrained_model`). You can also use the model repository if you uploaded a model checkpoint to the hub (e.g., `${HF_USER}/omx_act_policy`).
+- There is an additional `--policy.path` argument which indicates the path to your policy checkpoint (e.g., `outputs/train/eval_act_omx/checkpoints/last/pretrained_model`). You can also use the model repository if you uploaded a model checkpoint to the hub (e.g., `${HF_USER}/omx_act_policy`).
 - The dataset name begins with `eval_` to reflect that you are running inference (e.g., `${HF_USER}/eval_act_omx`).

--- a/docs/omx/lerobot_imitation_learning_omx.md
+++ b/docs/omx/lerobot_imitation_learning_omx.md
@@ -57,7 +57,7 @@ python -m lerobot.teleoperate \
 
 > **Note**: the `--robot.id/--teleop.id` values persist metadata (e.g., calibrations/settings). Use consistent IDs across teleop, recording, and evaluation for the same setup.
 
-### 2. Teleoperate with camera
+### 2. Teleoperate with Camera
 
 For camera integration:
 

--- a/docs/omx/opensource_omx.md
+++ b/docs/omx/opensource_omx.md
@@ -9,6 +9,7 @@ AI Manipulator is an open-source project that provides comprehensive resources f
 | **AI Manipulator** | ROS 2 Packages for operating the AI Manipulator | [GitHub](https://github.com/ROBOTIS-GIT/open_manipulator) |
 | **Physical AI Tools** | ROS 2 package for generating datasets in LeRobotDataset format | [GitHub](https://github.com/ROBOTIS-GIT/physical_ai_tools) |
 | **Simulation Models** | URDF(ROS), MJCF(MuJoCo) and USD(Isaac Sim/Lab) model files for simulation | [URDF](https://github.com/ROBOTIS-GIT/open_manipulator/tree/main/open_manipulator_description/urdf)<br>[MJCF](https://github.com/ROBOTIS-GIT/robotis_mujoco_menagerie)<br>[USD](https://github.com/ROBOTIS-GIT/robotis_lab/tree/main/source/robotis_lab/data/robots) |
+| **Drawing Files** | Hardware design files and technical drawings | **OMX-F:**<br>[PDF](https://www.robotis.com/service/download.php?no=2223) / [STEP](https://www.robotis.com/service/download.php?no=2224)<br>**OMX-L:**<br>[PDF](https://www.robotis.com/service/download.php?no=2225) / [STEP](https://www.robotis.com/service/download.php?no=2226) |
 | **AI Models & Datasets** | Pre-trained models and training datasets | [Hugging Face](https://huggingface.co/ROBOTIS) |
 | **Docker Images** | Ready-to-use development environments | [Docker Hub](https://hub.docker.com/r/robotis/ros/tags) |
 | **Documentation** | Official manual and documentation | [ai.robotis.com](https://ai.robotis.com) |

--- a/docs/omx/setup_guide_lerobot.md
+++ b/docs/omx/setup_guide_lerobot.md
@@ -1,3 +1,7 @@
+---
+next: false
+---
+
 # Setup Guide — LeRobot
 
 ::: warning

--- a/docs/omx/setup_guide_physical_ai_tools.md
+++ b/docs/omx/setup_guide_physical_ai_tools.md
@@ -80,7 +80,7 @@ Clone the repository:
 ```bash
 git clone https://github.com/ROBOTIS-GIT/open_manipulator
 ```
-Start the container with the following command:
+Start the **Open Manipulator** container with the following command:
 
 ```bash
 cd open_manipulator/docker && ./container.sh start

--- a/docs/omy/hardware_omy.md
+++ b/docs/omy/hardware_omy.md
@@ -29,7 +29,7 @@ The OMY hardware platform is a teleoperation system specifically designed for `i
 ## [Follower] Layout
 ![](/specifications/omy/omy_follower_layout.png)
 
-### **Drawing**
+### **Drawing Files**
   
 | File Type | Download Link |
 |-----------|---------------|
@@ -41,7 +41,7 @@ The OMY hardware platform is a teleoperation system specifically designed for `i
 
 ![](/specifications/omy/omy_follower_workspace.png)
 
-### **Drawing**
+### **Drawing File**
   
 | File Type | Download Link |
 |-----------|---------------|
@@ -223,7 +223,7 @@ The OMY hardware platform is a teleoperation system specifically designed for `i
 
 ![](/specifications/omy/omy_leader_layout.png)
 
-### **Drawing**
+### **Drawing Files**
   
 | File Type | Download Link |
 |-----------|---------------|

--- a/docs/omy/hardware_omy.md
+++ b/docs/omy/hardware_omy.md
@@ -29,11 +29,24 @@ The OMY hardware platform is a teleoperation system specifically designed for `i
 ## [Follower] Layout
 ![](/specifications/omy/omy_follower_layout.png)
 
-- `Download` [PDF](https://www.robotis.com/service/download.php?no=2208), [DWG](https://www.robotis.com/service/download.php?no=2207), [STEP](https://www.robotis.com/service/download.php?no=2209)
+### **Drawing**
+  
+| File Type | Download Link |
+|-----------|---------------|
+| PDF | [📄 Download PDF](https://www.robotis.com/service/download.php?no=2208) |
+| DWG | [💾 Download DWG](https://www.robotis.com/service/download.php?no=2207) |
+| STEP | [📦 Download STEP](https://www.robotis.com/service/download.php?no=2209) |
+
 ## [Follower] Workspace
 
 ![](/specifications/omy/omy_follower_workspace.png)
-- `Download` [PDF](https://www.robotis.com/service/download.php?no=2213)
+
+### **Drawing**
+  
+| File Type | Download Link |
+|-----------|---------------|
+| PDF | [📄 Download PDF](https://www.robotis.com/service/download.php?no=2213) |
+
 ## [Follower] Inertia
 
 ### Joint 1
@@ -209,7 +222,15 @@ The OMY hardware platform is a teleoperation system specifically designed for `i
 ## [Leader] Layout
 
 ![](/specifications/omy/omy_leader_layout.png)
-- `Download` [PDF](https://www.robotis.com/service/download.php?no=2211), [DWG](https://www.robotis.com/service/download.php?no=2210), [STEP](https://www.robotis.com/service/download.php?no=2212)
+
+### **Drawing**
+  
+| File Type | Download Link |
+|-----------|---------------|
+| PDF | [📄 Download PDF](https://www.robotis.com/service/download.php?no=2211) |
+| DWG | [💾 Download DWG](https://www.robotis.com/service/download.php?no=2210) |
+| STEP | [📦 Download STEP](https://www.robotis.com/service/download.php?no=2212) |
+
 
 ## [Leader] Inertia
 

--- a/docs/omy/opensource_omy.md
+++ b/docs/omy/opensource_omy.md
@@ -9,6 +9,7 @@ AI Manipulator is an open-source project that provides comprehensive resources f
 | **AI Manipulator** | ROS 2 Packages for operating the AI Manipulator | [GitHub](https://github.com/ROBOTIS-GIT/open_manipulator) |
 | **Physical AI Tools** | ROS 2 package for generating datasets in LeRobotDataset format | [GitHub](https://github.com/ROBOTIS-GIT/physical_ai_tools) |
 | **Simulation Models** | URDF(ROS), MJCF(MuJoCo) and USD(Isaac Sim/Lab) model files for simulation | [URDF](https://github.com/ROBOTIS-GIT/open_manipulator/tree/main/open_manipulator_description/urdf)<br>[MJCF](https://github.com/ROBOTIS-GIT/robotis_mujoco_menagerie)<br>[USD](https://github.com/ROBOTIS-GIT/robotis_lab/tree/main/source/robotis_lab/data/robots) |
+| **Drawing Files** | Hardware design files and technical drawings | **OMY-F3M:**<br>[PDF](https://www.robotis.com/service/download.php?no=2208)<br>[DWG](https://www.robotis.com/service/download.php?no=2207) / [STEP](https://www.robotis.com/service/download.php?no=2209)<br>**OMY-L100:**<br>[PDF](https://www.robotis.com/service/download.php?no=2211)<br>[DWG](https://www.robotis.com/service/download.php?no=2210) / [STEP](https://www.robotis.com/service/download.php?no=2212) |
 | **AI Models & Datasets** | Pre-trained models and training datasets | [Hugging Face](https://huggingface.co/ROBOTIS) |
 | **Docker Images** | Ready-to-use development environments | [Docker Hub](https://hub.docker.com/r/robotis/ros/tags) |
 | **Documentation** | Official manual and documentation | [ai.robotis.com](https://ai.robotis.com) |


### PR DESCRIPTION
### Changes
- OMX: 
  - Added drawing file download links to **Hardware** documentation and **Open Dource** documentation
  - Enhanced **Imitation Learning> LeRobot** documentation
- OMY: 
  - Added drawing file download links to **Open Source** documentation

--- 
#### OMX
- **Hardware** docs
<img width="500" height="219" alt="image" src="https://github.com/user-attachments/assets/629e8dc7-19a9-4067-a9a9-9b4b07c51dbc" />

- **Open Source** docs
<img width="500" height="152" alt="image" src="https://github.com/user-attachments/assets/408ce482-abb3-49a8-86c9-784942cb863a" />

#### OMY
- **Hardware** docs
<img width="500" height="245" alt="image" src="https://github.com/user-attachments/assets/72a4722b-f602-4907-b574-a4ecd03dfccb" />

- **Open Source** docs
<img width="500" height="204" alt="image" src="https://github.com/user-attachments/assets/4dbeb995-f842-466a-9a68-a9e978136cdf" />

