### PR TITLE
fix lerobot link in setup guide in omx

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -276,7 +276,7 @@ export default defineConfig({
               collapsed: false,
               items: [
                 { text: 'ROS 2 (Physical AI Tools)', link: '/omx/setup_guide_physical_ai_tools' },
-                { text: 'LeRobot', link: 'https://huggingface.co/docs/lerobot/installation', target: '_blank' }
+                { text: 'LeRobot', link: 'https://huggingface.co/docs/lerobot/omx', target: '_blank' }
               ]
             },
             { text: 'Operation Guide - ROS 2', link: '/omx/operation_omx' }

--- a/docs/omx/setup_guide_omx.md
+++ b/docs/omx/setup_guide_omx.md
@@ -40,6 +40,6 @@ Physical AI Tools Setup Guide
 #### LeRobot CLI (Alternative)
 **LeRobot** is the underlying robotics framework that powers Physical AI Tools. While it provides direct command-line control and is fully functional, it requires more technical expertise and lacks the web-based interface that makes robot control more accessible.
 
-<a href="/omx/setup_guide_lerobot.html" class="button-shortcut">
+<a href="https://huggingface.co/docs/lerobot/omx" class="button-shortcut" target="_blank" rel="noopener noreferrer">
 LeRobot Setup Guide
 </a>


### PR DESCRIPTION
fix lerobot link in setup guide in omx and fix lerobot link to 'https://huggingface.co/docs/lerobot/omx'